### PR TITLE
ヘッドレスモードで起動されたChromeでファイルのダウンロードを有効にする

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-rpa",
-  "version": "0.0.2-rc.3",
+  "version": "0.0.2-rc.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/WebBrowser.ts
+++ b/src/WebBrowser.ts
@@ -30,6 +30,7 @@ export class WebBrowser {
       ]
     });
     this.driver = new Builder().withCapabilities(this.capabilities).build();
+    this.enableDownloadInHeadlessChrome();
   }
 
   public get(url: string) {
@@ -147,9 +148,8 @@ export class WebBrowser {
 
   /**
    * Enable file downloads in Chrome running in headless mode
-   * @param downloadDir Destination Directory
    */
-  public enableDownloadInHeadlessChrome(downloadDir: string) {
+  private enableDownloadInHeadlessChrome() {
     /* eslint-disable no-underscore-dangle */
     const executor = (this.driver as any).getExecutor
       ? (this.driver as any).getExecutor()
@@ -164,7 +164,7 @@ export class WebBrowser {
       cmd: "Page.setDownloadBehavior",
       params: {
         behavior: "allow",
-        downloadPath: downloadDir
+        downloadPath: process.env.WORKSPACE_DIR
       }
     };
     this.driver.execute(new Command("send_command").setParameters(params));

--- a/src/WebBrowser.ts
+++ b/src/WebBrowser.ts
@@ -7,6 +7,7 @@ import {
   WebElement,
   WebElementPromise
 } from "selenium-webdriver";
+import { Command } from "selenium-webdriver/lib/command";
 
 import * as fs from "fs";
 import Logger from "./Logger";
@@ -137,6 +138,31 @@ export class WebBrowser {
         }
       }
     );
+  }
+
+  /**
+   * Enable file downloads in Chrome running in headless mode
+   * @param downloadDir Destination Directory
+   */
+  public enableDownloadInHeadlessChrome(downloadDir: string) {
+    /* eslint-disable no-underscore-dangle */
+    const executor = (this.driver as any).getExecutor
+      ? (this.driver as any).getExecutor()
+      : (this.driver as any).executor_;
+    /* eslint-enable no-underscore-dangle */
+    executor.defineCommand(
+      "send_command",
+      "POST",
+      "/session/:sessionId/chromium/send_command"
+    );
+    const params = {
+      cmd: "Page.setDownloadBehavior",
+      params: {
+        behavior: "allow",
+        downloadPath: downloadDir
+      }
+    };
+    this.driver.execute(new Command("send_command").setParameters(params));
   }
 }
 

--- a/src/WebBrowser.ts
+++ b/src/WebBrowser.ts
@@ -125,6 +125,11 @@ export class WebBrowser {
     return this.driver.findElements(By.xpath(xpath));
   }
 
+  public findElementByLinkText(text: string) {
+    Logger.debug(`WebBrowser.findElementByLinkText(${text})`);
+    return this.driver.findElement(By.linkText(text));
+  }
+
   public async takeScreenshot() {
     Logger.debug(`WebBrowser.takeScreenshot()`);
     const image = await this.driver.takeScreenshot();


### PR DESCRIPTION
HeadlessなChromeでは、click()やget(url)を実行してもダウンロードがされないので、
Page.setDownloadBehaviorでダウンロード時の動作を設定する関数を追加しました。

refs: https://chromedevtools.github.io/devtools-protocol/tot/Page#method-setDownloadBehavior

```sample.ts
import * as RPA from "./dist/index.js";

const sleep = msec => new Promise(resolve => setTimeout(resolve, msec));

(async () => {
  try {
    // コンストラクタで実行するようにしたので不要に
    // RPA.WebBrowser.enableDownloadInHeadlessChrome("./downloads");

    await RPA.WebBrowser.get(
      "https://chromedriver.storage.googleapis.com/index.html?path=75.0.3770.8/"
    );

    // SPAなのでちょっと待つ
    await sleep(1000);

    await RPA.WebBrowser.findElementByLinkText(
      "chromedriver_win32.zip"
    ).click();
  } catch (error) {
    RPA.systemLogger.error(error);
  }
})();
```

(findElementByLinkTextもちょっと欲しかったので追加してます)

resolve #8 