### PR TITLE
Fix: Drive からダウンロードしたファイルを gzip デコードする

### DIFF
--- a/src/google/Drive.ts
+++ b/src/google/Drive.ts
@@ -108,7 +108,7 @@ export default class Drive {
     headers: Headers,
     to: string
   ): Promise<void> {
-    const res = await request({ url, headers });
+    const res = await request({ url, headers, gzip: true });
     const out = fs.createWriteStream(to);
     return new Promise(
       (resolve, reject): void => {


### PR DESCRIPTION
ダウンロードしたファイルが gzip 圧縮されていてそのままでは開けないため（`.png`, `.jpg` など一部はそのまま開けるようでしたが）、gzip 圧縮されていればデコードするようにしました。

```js
(async () => {
  await RPA.Google.authorize(clientCredentials);
  await RPA.Google.Drive.download({ filename: '1.png', fileId: '...' });
  await RPA.Google.Drive.download({ filename: '2.jpg', fileId: '...' });
  await RPA.Google.Drive.download({ filename: '3.txt', fileId: '...' });
  await RPA.Google.Drive.download({ filename: '4.csv', fileId: '...' });
  await RPA.Google.Drive.download({ filename: '5.pdf', fileId: '...' });
})();
```