### PR TITLE
Add ChromeDriver74でcookieが消える問題の解決のためにChromeOptionsを追加する

### DIFF
--- a/src/WebBrowser.ts
+++ b/src/WebBrowser.ts
@@ -29,6 +29,7 @@ export class WebBrowser {
       "--no-sandbox",
       "--disable-gpu",
       "--window-size=1980,1200",
+      "--enable-features=NetworkService,NetworkServiceInProcess", // refs: https://bugs.chromium.org/p/chromedriver/issues/detail?id=2897
       `--user-data-dir=${WebBrowser.outDir}/user-data`
     ];
     if (WebBrowser.headless) {


### PR DESCRIPTION

refs:
2897 - Cookies are randomly lost after 30 seconds while running headlessly - chromedriver - Monorail
https://bugs.chromium.org/p/chromedriver/issues/detail?id=2897
