### PR TITLE
Add Slack

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -402,6 +402,38 @@
         "@types/yargs": "^12.0.9"
       }
     },
+    "@slack/logger": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@slack/logger/-/logger-1.0.0.tgz",
+      "integrity": "sha512-QDYhQR/58xKfB5iquvQwfpxPsmKPP/5SuDp8hRhZeUluCHsP1qBCOc3sW2Xb3cydxK0PAEnkLbBJf/ezsGwtlA==",
+      "requires": {
+        "@types/node": ">=8.9.0"
+      }
+    },
+    "@slack/types": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@slack/types/-/types-1.0.0.tgz",
+      "integrity": "sha512-IktC4uD/CHfLQcSitKSmjmRu4a6+Nf/KzfS6dTgUlDzENhh26l8aESKAuIpvYD5VOOE6NxDDIAdPJOXBvUGxlg=="
+    },
+    "@slack/web-api": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-5.0.1.tgz",
+      "integrity": "sha512-L2Nc8P+NjXH1yqnsNhqxsrbpW3Qv+//9X5PQqcM3bctDmvmwTuhuM1X208RVD2avhnC89aghY5PssyaayWj5sA==",
+      "requires": {
+        "@slack/logger": "^1.0.0",
+        "@slack/types": "^1.0.0",
+        "@types/form-data": "^2.2.1",
+        "@types/is-stream": "^1.1.0",
+        "@types/node": ">=8.9.0",
+        "@types/p-queue": "^2.3.2",
+        "axios": "^0.18.0",
+        "eventemitter3": "^3.1.0",
+        "form-data": "^2.3.3",
+        "is-stream": "^1.1.0",
+        "p-queue": "^2.4.2",
+        "p-retry": "^4.0.0"
+      }
+    },
     "@types/babel__core": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.0.tgz",
@@ -443,6 +475,22 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/form-data": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-2.2.1.tgz",
+      "integrity": "sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha512-jkZatu4QVbR60mpIzjINmtS1ZF4a/FqdTUTBeQDVOQ2PYyidtwFKr0B5G6ERukKwliq+7mIXvxyppwzG5EgRYg==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.0.tgz",
@@ -482,6 +530,16 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/p-queue": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@types/p-queue/-/p-queue-2.3.2.tgz",
+      "integrity": "sha512-eKAv5Ql6k78dh3ULCsSBxX6bFNuGjTmof5Q/T6PiECDq0Yf8IIn46jCyp3RJvCi8owaEmm3DZH1PEImjBMd/vQ=="
+    },
+    "@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="
     },
     "@types/selenium-webdriver": {
       "version": "4.0.0",
@@ -769,6 +827,15 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
+    },
+    "axios": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+      "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+      "requires": {
+        "follow-redirects": "^1.3.0",
+        "is-buffer": "^1.1.5"
+      }
     },
     "babel-jest": {
       "version": "24.7.1",
@@ -2113,6 +2180,11 @@
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
     },
+    "eventemitter3": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
+    },
     "exec-sh": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.2.tgz",
@@ -2459,6 +2531,14 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.0.tgz",
       "integrity": "sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg=="
+    },
+    "follow-redirects": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.7.0.tgz",
+      "integrity": "sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==",
+      "requires": {
+        "debug": "^3.2.6"
+      }
     },
     "for-in": {
       "version": "1.0.2",
@@ -3669,8 +3749,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-callable": {
       "version": "1.1.4",
@@ -3797,8 +3876,7 @@
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-      "dev": true
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
     "is-symbol": {
       "version": "1.0.2",
@@ -5293,11 +5371,25 @@
         "p-limit": "^2.0.0"
       }
     },
+    "p-queue": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-2.4.2.tgz",
+      "integrity": "sha512-n8/y+yDJwBjoLQe1GSJbbaYQLTI7QHNZI2+rpmCDbe++WLf9HC3gf6iqj5yfPAV71W4UF3ql5W1+UBPXoXTxng=="
+    },
     "p-reduce": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
       "integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=",
       "dev": true
+    },
+    "p-retry": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.1.0.tgz",
+      "integrity": "sha512-oepllyG9gX1qH4Sm20YAKxg1GA7L7puhvGnTfimi31P07zSIj7SDV6YtuAx9nbJF51DES+2CIIRkXs8GKqWJxA==",
+      "requires": {
+        "@types/retry": "^0.12.0",
+        "retry": "^0.12.0"
+      }
     },
     "p-try": {
       "version": "2.2.0",
@@ -5753,6 +5845,11 @@
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "dev": true
+    },
+    "retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
     },
     "rfdc": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@slack/web-api": "^5.0.1",
     "@types/node": "^11.11.1",
     "@types/node-forge": "^0.8.3",
     "@types/selenium-webdriver": "^4.0.0",

--- a/src/Slack.ts
+++ b/src/Slack.ts
@@ -1,0 +1,26 @@
+import { WebClient } from "@slack/web-api";
+
+class Slack extends WebClient {
+  private static slack: Slack;
+
+  // Override readonly field
+  public token?: string;
+
+  /* eslint-disable no-useless-constructor */
+  private constructor() {
+    super();
+  }
+
+  public static get instance(): Slack {
+    if (!this.slack) {
+      this.slack = new Slack();
+    }
+    return this.slack;
+  }
+
+  public initialise(credential: { apiToken: string }): void {
+    this.token = credential.apiToken;
+  }
+}
+
+export default Slack.instance;

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,8 @@ export * from "./google";
 
 export { default as Chatwork } from "./Chatwork";
 
+export { default as Slack } from "./Slack";
+
 export * from "./CSV";
 
 export * from "./Zip";


### PR DESCRIPTION
Slack 公式のライブラリがいい感じだったのでほぼそのままです。
https://github.com/slackapi/node-slack-sdk
https://api.slack.com/web

もともと API キーをコンストラクタで指定するようなインタフェースになっているのですが、Chatwork や Google に合わせて、インスタンスを 1 つ export して `initialise` で API キー設定するように書き換えています。

```js
import * as RPA from "ts-rpa"

const SLACK_API_TOKEN = '...';
const conversationId = '...';
(async () => {
  await RPA.Slack.initialise({ apiToken: SLACK_API_TOKEN });
  await RPA.Slack.chat.postMessage({
    channel: conversationId,
    text: 'Hello Slack'
  });
})();
```