### PR TITLE
Add `getCurrentUrl`, `getCookie`, `getCookies`

### DIFF
--- a/src/WebBrowser.ts
+++ b/src/WebBrowser.ts
@@ -3,6 +3,7 @@ import {
   By,
   Capabilities,
   Condition,
+  IWebDriverOptionsCookie,
   ThenableWebDriver,
   WebElement
 } from "selenium-webdriver";
@@ -182,6 +183,16 @@ export class WebBrowser {
   public getCurrentUrl(): Promise<string> {
     Logger.debug("WebBrowser.getCurrentUrl()");
     return this.driver.getCurrentUrl();
+  }
+
+  public getCookie(name: string): Promise<IWebDriverOptionsCookie> {
+    Logger.debug(`WebBrowser.getCookie(${name})`);
+    return this.driver.manage().getCookie(name);
+  }
+
+  public getCookies(): Promise<IWebDriverOptionsCookie[]> {
+    Logger.debug("WebBrowser.getCookies()");
+    return this.driver.manage().getCookies();
   }
 
   /**

--- a/src/WebBrowser.ts
+++ b/src/WebBrowser.ts
@@ -179,6 +179,11 @@ export class WebBrowser {
     );
   }
 
+  public getCurrentUrl(): Promise<string> {
+    Logger.debug("WebBrowser.getCurrentUrl()");
+    return this.driver.getCurrentUrl();
+  }
+
   /**
    * Enable file downloads in Chrome running in headless mode
    */


### PR DESCRIPTION
よく使うメソッドを `WebBrowser` に追加しました。

```js
import * as RPA from "ts-rpa";

(async () => {
  await RPA.WebBrowser.get("https://github.com");
  console.log(await RPA.WebBrowser.getCurrentUrl());  // -> https://github.com/

  const cookie = await RPA.WebBrowser.getCookie("logged_in");
  console.log(cookie.value);  // -> no
})();
```