### PR TITLE
Support Shift_JIS CSV

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3408,7 +3408,6 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "gaxios": "^2.0.1",
     "googleapis": "^40.0.0",
     "googleapis-common": "^2.0.0",
+    "iconv-lite": "^0.4.24",
     "is-utf8": "^0.2.1",
     "log4js": "^4.3.1",
     "mime-stream": "^1.0.1",

--- a/src/CSV.ts
+++ b/src/CSV.ts
@@ -1,5 +1,6 @@
 import * as path from "path";
 import * as fs from "fs";
+import * as iconv from "iconv-lite";
 import * as parse from "csv-parse";
 import * as writer from "csv-writer";
 import File from "./File";
@@ -24,7 +25,8 @@ export namespace RPA {
       return new Promise(
         (resolve, reject): void => {
           const results = [];
-          fs.createReadStream(filePath, { encoding: params.encoding })
+          fs.createReadStream(filePath)
+            .pipe(iconv.decodeStream(params.encoding || "utf8"))
             .pipe(
               parse({
                 bom: params.bom,


### PR DESCRIPTION
`fs.createReadStream` では Shift_JIS を扱うことができないため、`iconv-lite` で変換するようにしました。Node のエンコーディングにそのまま対応しているため既存のコードに影響はありません。
https://github.com/ashtuchkin/iconv-lite/wiki/Supported-Encodings
