### PR TITLE
Drive, URLでのダウンロード時に認証情報をもたせる

### DIFF
--- a/src/Google/Drive.ts
+++ b/src/Google/Drive.ts
@@ -129,11 +129,19 @@ export namespace RPA {
           return outFilename;
         }
         if (params.url && params.filename) {
+          const queryParams = new URL(params.url).searchParams;
+          /* eslint-disable no-underscore-dangle */
           await Drive.fetch(
-            `${params.url}?alt=media`,
-            this.api.files.context._options.headers, // eslint-disable-line no-underscore-dangle
+            `${params.url}${queryParams ? "&" : "?"}alt=media`,
+            {
+              Authorization: `Bearer ${
+                (await (this.api.context._options
+                  .auth as OAuth2Client).getAccessToken()).token
+              }`
+            },
             path.join(this.outDir, outFilename)
           );
+          /* eslint-enable no-underscore-dangle */
           return outFilename;
         }
         throw Error("Invalid parameter.");


### PR DESCRIPTION
URLでのダウンロード時に認証できずに401がでていたので認証情報をつけてリクエストするようにしました