### PR TITLE
Spreadsheet に日付や関数を入力できるようにする

### DIFF
--- a/src/Google/Spreadsheet.ts
+++ b/src/Google/Spreadsheet.ts
@@ -38,12 +38,13 @@ export namespace RPA {
         spreadsheetId: string;
         range: string;
         values: string[][];
+        parseValues?: boolean;
       }): Promise<sheetsApi.Schema$UpdateValuesResponse> {
         const res = await this.api.spreadsheets.values.update(
           {
             spreadsheetId: params.spreadsheetId,
             range: params.range,
-            valueInputOption: "RAW"
+            valueInputOption: params.parseValues ? "USER_ENTERED" : "RAW"
           },
           {
             body: JSON.stringify({


### PR DESCRIPTION
現状、日時や関数を文字列で入力すると文字列として入力されます。
日時や関数をパースしてもらえるようにオプションを追加しました。