### PR TITLE
Add Spreadsheet.setCellsFormat

### DIFF
--- a/src/Google/Spreadsheet.ts
+++ b/src/Google/Spreadsheet.ts
@@ -7,7 +7,7 @@ export namespace RPA {
     export class Spreadsheet {
       private static spreadsheet: Spreadsheet;
 
-      public api: sheetsApi.Sheets;
+      private api: sheetsApi.Sheets;
 
       private constructor() {} // eslint-disable-line no-useless-constructor, no-empty-function
 

--- a/src/Google/Spreadsheet.ts
+++ b/src/Google/Spreadsheet.ts
@@ -7,7 +7,7 @@ export namespace RPA {
     export class Spreadsheet {
       private static spreadsheet: Spreadsheet;
 
-      private api: sheetsApi.Sheets;
+      public api: sheetsApi.Sheets;
 
       private constructor() {} // eslint-disable-line no-useless-constructor, no-empty-function
 
@@ -214,6 +214,29 @@ export namespace RPA {
         });
         Logger.debug("Google.Spreadsheet.copySheet", params);
         return res.data.sheetId;
+      }
+
+      public async setCellsFormat(params: {
+        spreadsheetId: string;
+        range: sheetsApi.Schema$GridRange;
+        format: sheetsApi.Schema$CellFormat;
+      }): Promise<sheetsApi.Schema$Spreadsheet> {
+        const res = await this.api.spreadsheets.batchUpdate({
+          spreadsheetId: params.spreadsheetId,
+          requestBody: {
+            requests: [
+              {
+                repeatCell: {
+                  range: params.range,
+                  cell: { userEnteredFormat: params.format },
+                  fields: "userEnteredFormat"
+                }
+              }
+            ]
+          }
+        });
+        Logger.debug("Google.Spreadsheet.setCellsFormat", params);
+        return res.data.updatedSpreadsheet;
       }
     }
   }


### PR DESCRIPTION
Spreadsheet のセル書式を設定できるようにしました。
refs: https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets/cells?hl=ja#CellFormat

```typescript
await RPA.Google.Spreadsheet.setCellsFormat({
  spreadsheetId: "...",
  range: {
    sheetId: ...,
    startRowIndex: 0,
    startColumnIndex: 0,
    endRowIndex: 5,
    endColumnIndex: 3,
  },
  format: {
    backgroundColor: {
      red: 0.2,
      green: 0.55,
      blue: 0.25
    },
  }
});
```
