### PR TITLE
add Spreadsheet protected

### DIFF
--- a/src/RPA/Google/Spreadsheet.ts
+++ b/src/RPA/Google/Spreadsheet.ts
@@ -238,6 +238,50 @@ export namespace RPA {
         Logger.debug("Google.Spreadsheet.setCellsFormat", params);
         return res.data.updatedSpreadsheet;
       }
+
+      public async addProtectedRange(params: {
+        spreadsheetId: string;
+        range: sheetsApi.Schema$GridRange;
+        description: string;
+      }): Promise<sheetsApi.Schema$ProtectedRange> {
+        const res = await this.api.spreadsheets.batchUpdate({
+          spreadsheetId: params.spreadsheetId,
+          requestBody: {
+            requests: [
+              {
+                addProtectedRange: {
+                  protectedRange: {
+                    range: params.range,
+                    description: params.description,
+                    warningOnly: true
+                  }
+                }
+              }
+            ]
+          }
+        });
+        Logger.debug("Google.Spreadsheet.addProtectedRange", params);
+        return res.data.replies[0].addProtectedRange.protectedRange;
+      }
+
+      public async deleteProtectedRange(params: {
+        spreadsheetId: string;
+        protectedRangeId: number;
+      }): Promise<void> {
+        const res = await this.api.spreadsheets.batchUpdate({
+          spreadsheetId: params.spreadsheetId,
+          requestBody: {
+            requests: [
+              {
+                deleteProtectedRange: {
+                  protectedRangeId: params.protectedRangeId
+                }
+              }
+            ]
+          }
+        });
+        Logger.debug("Google.Spreadsheet.deleteProtectedRange", params);
+      }
     }
   }
 }


### PR DESCRIPTION
Spreadsheetの指定した範囲を保護できるようにしました。
ts-rpa(bot)が実行中に、手動でデータを触らせたくないときに使えそうです。

addProtectedRangeで作って作業が終わったら追加したときのResponseに含まれているprotectedRangeIdを使って保護を削除する流れでdeleteProtectedRangeも追加してます。

```typescript
  const res = await RPA.Google.Spreadsheet.addProtectedRange({
    spreadsheetId: "hogehoge",
    range: {
      sheetId: sheetId
    },
    description: "test"
  });
  await RPA.Google.Spreadsheet.deleteProtectedRange({
    spreadsheetId: "hogehoge",
    protectedRangeId: res.protectedRangeId
  });
```