### PR TITLE
Add GCP.BigQuery

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ export WEB_BROWSER_HEADLESS=true
 export GOOGLE_CLIENT_SECRET=************************
 export GOOGLE_CLIENT_ID=************-********************************.apps.googleusercontent.com
 export WORKSPACE_DIR=./tmp/
+
+# If you plan to use `RPA.GCP` module, you need to set a service account key file.
+# https://cloud.google.com/docs/authentication/getting-started
+export GOOGLE_APPLICATION_CREDENTIALS=************-************.json
 ```
 
 ## Usage
@@ -44,9 +48,9 @@ import RPA from "ts-rpa";
     await RPA.sleep(3000);
     await RPA.WebBrowser.takeScreenshot();
   } catch (error) {
-    RPA.systemLogger.error(error);
+    RPA.SystemLogger.error(error);
   } finally {
-    RPA.WebBrowser.quit();
+    await RPA.WebBrowser.quit();
   }
 })();
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -221,6 +221,83 @@
         }
       }
     },
+    "@google-cloud/bigquery": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@google-cloud/bigquery/-/bigquery-4.1.5.tgz",
+      "integrity": "sha512-dCUmc+KYdEl7naTV8MYVBCZvOchgk4rMa0aTjPhf17VJuTg8PKbl/lNDxhe7oe0CBBMPIPtFwe6clLPZhcsx7g==",
+      "requires": {
+        "@google-cloud/common": "^2.0.0",
+        "@google-cloud/paginator": "^2.0.0",
+        "@google-cloud/promisify": "^1.0.0",
+        "arrify": "^2.0.1",
+        "big.js": "^5.2.2",
+        "duplexify": "^4.0.0",
+        "extend": "^3.0.2",
+        "is": "^3.3.0",
+        "stream-events": "^1.0.5",
+        "string-format-obj": "^1.1.1",
+        "uuid": "^3.3.2"
+      }
+    },
+    "@google-cloud/common": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-2.0.4.tgz",
+      "integrity": "sha512-Q2QN2KL+6w8Idl2mAI01Q72ZizJdQ+aPJUYQ+COwnUR7njskjdtHHU/Jh14ilNIzOMw+OIdIF4ebwOdsqh23QQ==",
+      "requires": {
+        "@google-cloud/projectify": "^1.0.0",
+        "@google-cloud/promisify": "^1.0.0",
+        "@types/request": "^2.48.1",
+        "arrify": "^2.0.0",
+        "duplexify": "^3.6.0",
+        "ent": "^2.2.0",
+        "extend": "^3.0.2",
+        "google-auth-library": "^4.0.0",
+        "retry-request": "^4.0.0",
+        "teeny-request": "^4.0.0"
+      },
+      "dependencies": {
+        "duplexify": {
+          "version": "3.7.1",
+          "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
+          "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
+          "requires": {
+            "end-of-stream": "^1.0.0",
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.0",
+            "stream-shift": "^1.0.0"
+          }
+        },
+        "teeny-request": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-4.0.0.tgz",
+          "integrity": "sha512-Kk87eePsBQZsn5rOIwupObYV7doBMedW3fUOmu3LFVRGEJQ7oeClwWkGFS3nkFs9TFL36qf08vGJd34swMorHQ==",
+          "requires": {
+            "https-proxy-agent": "^2.2.1",
+            "node-fetch": "^2.2.0",
+            "uuid": "^3.3.2"
+          }
+        }
+      }
+    },
+    "@google-cloud/paginator": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-2.0.0.tgz",
+      "integrity": "sha512-droVsitvSUGSoMV7Hbk2B5dCFkZIz9YNu3D1AxgFh+hmbSEWJ9SgB/M3WrU8CUx3pseH7IbLuq8jgs3HEFzeHw==",
+      "requires": {
+        "arrify": "^2.0.0",
+        "extend": "^3.0.1"
+      }
+    },
+    "@google-cloud/projectify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-1.0.1.tgz",
+      "integrity": "sha512-xknDOmsMgOYHksKc1GPbwDLsdej8aRNIA17SlSZgQdyrcC0lx0OGo4VZgYfwoEU1YS8oUxF9Y+6EzDOb0eB7Xg=="
+    },
+    "@google-cloud/promisify": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-1.0.2.tgz",
+      "integrity": "sha512-7WfV4R/3YV5T30WRZW0lqmvZy9hE2/p9MvpI34WuKa2Wz62mLu5XplGTFEMK6uTbJCLWUxTcZ4J4IyClKucE5g=="
+    },
     "@jest/console": {
       "version": "24.7.1",
       "resolved": "https://registry.npmjs.org/@jest/console/-/console-24.7.1.tgz",
@@ -460,6 +537,11 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/caseless": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
+      "integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w=="
+    },
     "@types/eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
@@ -621,6 +703,17 @@
       "resolved": "https://registry.npmjs.org/@types/p-queue/-/p-queue-2.3.2.tgz",
       "integrity": "sha512-eKAv5Ql6k78dh3ULCsSBxX6bFNuGjTmof5Q/T6PiECDq0Yf8IIn46jCyp3RJvCi8owaEmm3DZH1PEImjBMd/vQ=="
     },
+    "@types/request": {
+      "version": "2.48.2",
+      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.2.tgz",
+      "integrity": "sha512-gP+PSFXAXMrd5PcD7SqHeUjdGshAI8vKQ3+AvpQr3ht9iQea+59LOKvKITcQI+Lg+1EIkDP6AFSBUJPWG8GDyA==",
+      "requires": {
+        "@types/caseless": "*",
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "form-data": "^2.5.0"
+      }
+    },
     "@types/retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
@@ -646,6 +739,11 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
       "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
       "dev": true
+    },
+    "@types/tough-cookie": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.5.tgz",
+      "integrity": "sha512-SCcK7mvGi3+ZNz833RRjFIxrn4gI1PPR3NtuIS+6vMkvmsGjosqTJwRt5bAEFLRz+wtJMWv8+uOnZf2hi2QXTg=="
     },
     "@types/yargs": {
       "version": "12.0.12",
@@ -1121,6 +1219,11 @@
       "version": "1.6.44",
       "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.44.tgz",
       "integrity": "sha512-7MzElZPTyJ2fNvBkPxtFQ2fWIkVmuzw41+BZHSzpEq3ymB2MfeKp1+yXl/tS75xCx+WnyV+yb0kp+K1C3UNwmQ=="
+    },
+    "big.js": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
     },
     "bignumber.js": {
       "version": "7.2.1",
@@ -1749,6 +1852,29 @@
         "readable-stream": "^2.0.2"
       }
     },
+    "duplexify": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.1.tgz",
+      "integrity": "sha512-DY3xVEmVHTv1wSzKNbwoU6nVjzI369Y6sPoqfYr0/xlx3IdX2n94xIszTcjPO8W8ZIv0Wb0PXNcjuZyT4wiICA==",
+      "requires": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -1777,10 +1903,14 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
-      "dev": true,
       "requires": {
         "once": "^1.4.0"
       }
+    },
+    "ent": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
+      "integrity": "sha1-6WQhkyWiHQX0RGai9obtbOX13R0="
     },
     "error-ex": {
       "version": "1.3.2",
@@ -3637,6 +3767,11 @@
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
       "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
       "dev": true
+    },
+    "is": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/is/-/is-3.3.0.tgz",
+      "integrity": "sha512-nW24QBoPcFGGHJGUwnfpI7Yc5CdqWNdsyHQszVE/z2pKHXzh7FZ5GWhJqSyaQ9wMkQnsTx+kAI8bHlCX4tKdbg=="
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
@@ -5688,6 +5823,25 @@
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
       "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
     },
+    "retry-request": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-4.1.1.tgz",
+      "integrity": "sha512-BINDzVtLI2BDukjWmjAIRZ0oglnCAkpP2vQjM3jdLhmT62h0xnQgciPwBRDAvHqpkPT2Wo1XuUyLyn6nbGrZQQ==",
+      "requires": {
+        "debug": "^4.1.1",
+        "through2": "^3.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
+    },
     "rfdc": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.1.4.tgz",
@@ -6161,6 +6315,19 @@
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
       "dev": true
     },
+    "stream-events": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
+      "integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
+      "requires": {
+        "stubs": "^3.0.0"
+      }
+    },
+    "stream-shift": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
+    },
     "stream-transform": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/stream-transform/-/stream-transform-1.0.8.tgz",
@@ -6177,6 +6344,11 @@
         "fs-extra": "^7.0.1",
         "lodash": "^4.17.14"
       }
+    },
+    "string-format-obj": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string-format-obj/-/string-format-obj-1.1.1.tgz",
+      "integrity": "sha512-Mm+sROy+pHJmx0P/0Bs1uxIX6UhGJGj6xDGQZ5zh9v/SZRmLGevp+p0VJxV7lirrkAmQ2mvva/gHKpnF/pTb+Q=="
     },
     "string-length": {
       "version": "2.0.0",
@@ -6266,6 +6438,11 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
+    },
+    "stubs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
+      "integrity": "sha1-6NK6H6nJBXAwPAMLaQD31fiavls="
     },
     "supports-color": {
       "version": "6.1.0",
@@ -6462,6 +6639,14 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
+    },
+    "through2": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
+      "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+      "requires": {
+        "readable-stream": "2 || 3"
+      }
     },
     "tmp": {
       "version": "0.0.30",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@google-cloud/bigquery": "^4.1.5",
     "@slack/web-api": "^5.0.1",
     "@types/node": "^12.6.8",
     "@types/node-fetch": "^2.3.7",

--- a/src/RPA/File.ts
+++ b/src/RPA/File.ts
@@ -8,7 +8,7 @@ export namespace RPA {
   export class File {
     private constructor() {} // eslint-disable-line no-useless-constructor, no-empty-function
 
-    private static outDir: string = process.env.WORKSPACE_DIR || "./";
+    public static readonly outDir: string = process.env.WORKSPACE_DIR || "./";
 
     public static rename(params: { old: string; new: string }): void {
       Logger.debug("File.rename", params);

--- a/src/RPA/GCP/BigQuery.ts
+++ b/src/RPA/GCP/BigQuery.ts
@@ -1,0 +1,38 @@
+import {
+  BigQuery as Client,
+  Query,
+  QueryOptions,
+  SimpleQueryRowsResponse
+} from "@google-cloud/bigquery";
+import Logger from "../Logger";
+
+export namespace RPA {
+  export namespace GCP {
+    export class BigQuery {
+      private static bigQuery: BigQuery;
+
+      private client: Client;
+
+      private constructor() {
+        this.client = new Client();
+      }
+
+      public static get instance(): BigQuery {
+        if (!this.bigQuery) {
+          this.bigQuery = new BigQuery();
+        }
+        return this.bigQuery;
+      }
+
+      public async query(
+        query: Query,
+        options?: QueryOptions
+      ): Promise<SimpleQueryRowsResponse> {
+        Logger.debug("BigQuery.query", query, options);
+        return this.client.query(query, options);
+      }
+    }
+  }
+}
+
+export default RPA.GCP.BigQuery;

--- a/src/RPA/GCP/index.ts
+++ b/src/RPA/GCP/index.ts
@@ -1,0 +1,9 @@
+import * as GCPBigQuery from "./BigQuery";
+
+export namespace RPA {
+  export namespace GCP {
+    export const BigQuery = GCPBigQuery.default.instance;
+  }
+}
+
+export default RPA.GCP;

--- a/src/RPA/GCP/index.ts
+++ b/src/RPA/GCP/index.ts
@@ -1,5 +1,19 @@
 import * as GCPBigQuery from "./BigQuery";
 
+import File from "../File";
+import Hash from "../Hash";
+
+if (process.env.GOOGLE_APPLICATION_CREDENTIALS_CONTENT) {
+  const credentialsFile = `${Hash.md5(
+    process.env.GOOGLE_APPLICATION_CREDENTIALS_CONTENT
+  )}.json`;
+  File.write({
+    filename: credentialsFile,
+    data: process.env.GOOGLE_APPLICATION_CREDENTIALS_CONTENT
+  });
+  process.env.GOOGLE_APPLICATION_CREDENTIALS = File.outDir + credentialsFile;
+}
+
 export namespace RPA {
   export namespace GCP {
     export const BigQuery = GCPBigQuery.default.instance;

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,8 @@ import * as LoggerModule from "./RPA/Logger";
 
 import GoogleModule from "./RPA/Google";
 
+import GCPModule from "./RPA/GCP";
+
 import SlackModule from "./RPA/Slack";
 
 import ChatworkModule from "./RPA/Chatwork";
@@ -22,6 +24,8 @@ import RequestModule from "./RPA/Request";
 
 export namespace RPA {
   export const Google = GoogleModule;
+
+  export const GCP = GCPModule;
 
   export const Slack = SlackModule;
 


### PR DESCRIPTION
GCP モジュールを追加し、BigQuery にクエリを発行できるようにしました。

```typescript
import RPA from "ts-rpa";

(async () => {
  const sql = `
SELECT * FROM \`bigquery-public-data.ml_datasets.iris\`
WHERE petal_width > @petal_width
LIMIT 10
`;
  const res = await RPA.GCP.BigQuery.query({
    query: sql,
    params: {
      petal_width: 1.0
    }
  });
  res.forEach(row => {
    console.log(row);
  });
})();
```

### .env

```sh
# キーファイルを指定
# https://cloud.google.com/docs/authentication/getting-started
export GOOGLE_APPLICATION_CREDENTIALS=************-************.json
# またはキーファイルの中身を文字列で指定
export GOOGLE_APPLICATION_CREDENTIALS_CONTENT={"type": "service_account", ...}
```
