### PR TITLE
Feature/fix spreadsheet protected

### DIFF
--- a/src/RPA/Google/Gmail.ts
+++ b/src/RPA/Google/Gmail.ts
@@ -25,6 +25,14 @@ export namespace RPA {
         this.api = google.gmail({ version: "v1", auth });
       }
 
+      public async getProfile(
+        params: gmailApi.Params$Resource$Users$Getprofile
+      ): Promise<gmailApi.Schema$Profile> {
+        const profile = await this.api.users.getProfile(params);
+        Logger.debug("Gmail.getProfile");
+        return profile.data;
+      }
+
       public async send(params: MailOptions): Promise<string> {
         Logger.debug("Gmail.send", params);
         const message = await Gmail.buildMessage(params);

--- a/src/RPA/Google/Spreadsheet.ts
+++ b/src/RPA/Google/Spreadsheet.ts
@@ -262,8 +262,7 @@ export namespace RPA {
 
       public async addProtectedRange(params: {
         spreadsheetId: string;
-        range: sheetsApi.Schema$GridRange;
-        description: string;
+        protectedRange: sheetsApi.Schema$ProtectedRange;
       }): Promise<sheetsApi.Schema$ProtectedRange> {
         const res = await this.api.spreadsheets.batchUpdate({
           spreadsheetId: params.spreadsheetId,
@@ -271,11 +270,7 @@ export namespace RPA {
             requests: [
               {
                 addProtectedRange: {
-                  protectedRange: {
-                    range: params.range,
-                    description: params.description,
-                    warningOnly: true
-                  }
+                  protectedRange: params.protectedRange
                 }
               }
             ]


### PR DESCRIPTION

https://github.com/ca-rpa/ts-rpa/pull/67 の 
addProtectedRangeがアレな感じだったのでを汎用的に修正しました＞＜
 
またeditors.usersに自分を追加できるようにGmail.getProfileを追加しています。
```typescript
  const profile = await RPA.Google.Gmail.getProfile({
    userId: "me"
  });
  await RPA.Google.Spreadsheet.addProtectedRange({
    spreadsheetId: "hogehoge",
    protectedRange: {
      range: { sheetId: 372997165 },
      description: "aa",
      editors: {
        users: [profile.emailAddress]
      },
      warningOnly: false
    }
  });
```