### PR TITLE
Allow Function as condition of WebBrowser.wait

### DIFF
--- a/src/RPA/WebBrowser.ts
+++ b/src/RPA/WebBrowser.ts
@@ -77,7 +77,7 @@ export namespace RPA {
     }
 
     public wait<T>(
-      condition: Condition<T> | PromiseLike<T>,
+      condition: Condition<T> | PromiseLike<T> | Function,
       optTimeout?: number
     ): Promise<T> {
       Logger.debug("WebBrowser.wait", { condition, optTimeout });


### PR DESCRIPTION
`RPA.WebBrowser.wait` に関数を渡せるようにしました。

```typescript
await RPA.WebBrowser.wait(async () => {
  const button = await RPA.WebBrowser.findElement('.button');
  const until = (await button.getCssValue('color')) === 'red';
  return until;
}, 10000);
```