### PR TITLE
Add String.halveZenkakuAscii

### DIFF
--- a/src/RPA/String.ts
+++ b/src/RPA/String.ts
@@ -1,0 +1,22 @@
+import Logger from "./Logger";
+
+export namespace RPA {
+  export class StringClass {
+    private constructor() {} // eslint-disable-line no-useless-constructor, no-empty-function
+
+    public static halveZenkakuAscii(str: string): string {
+      Logger.debug("String.halveZenkakuAscii", str);
+      return (
+        str
+          // ascii
+          .replace(/[\uff01-\uff5e]/g, (c): string =>
+            String.fromCodePoint(c.codePointAt(0) - 0xfee0)
+          )
+          // full-width space
+          .replace(/\u3000/g, " ")
+      );
+    }
+  }
+}
+
+export default RPA.StringClass;

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import HashModule from "./RPA/Hash";
 import ZipModule from "./RPA/Zip";
 
 import RequestModule from "./RPA/Request";
+import StringModule from "./RPA/String";
 
 export namespace RPA {
   export const Google = GoogleModule;
@@ -40,6 +41,8 @@ export namespace RPA {
   export const Zip = ZipModule;
 
   export const Request = RequestModule;
+
+  export const String = StringModule;
 
   export const WebBrowser = WebBrowserModule.default;
 

--- a/tests/String.spec.ts
+++ b/tests/String.spec.ts
@@ -1,0 +1,19 @@
+import StringClass from "../src/RPA/String";
+
+describe("RPA.String", () => {
+  describe("halveZenkakuAscii", () => {
+    it("halves all ascii chars", async () => {
+      expect(
+        StringClass.halveZenkakuAscii(
+          "Ｔｈｅ　ｑｕｉｃｋ　ｂｒｏｗｎ　ｆｏｘ　ｊｕｍｐｓ　ｏｖｅｒ　ｔｈｅ　ｌａｚｙ　ｄｏｇ！　１２３４５６７８９０．"
+        )
+      ).toBe("The quick brown fox jumps over the lazy dog! 1234567890.");
+    });
+
+    it("skips half-width or non-ascii chars", async () => {
+      expect(StringClass.halveZenkakuAscii("abcあいう１２３一二三")).toBe(
+        "abcあいう123一二三"
+      );
+    });
+  });
+});


### PR DESCRIPTION
全角 ASCII 文字を半角に変換できるようにしました。

```typescript
RPA.String.halveZenkakuAscii(
  "Ｔｈｅ　ｑｕｉｃｋ　ｂｒｏｗｎ　ｆｏｘ　ｊｕｍｐｓ　ｏｖｅｒ　ｔｈｅ　ｌａｚｙ　ｄｏｇ！　１２３４５６７８９０．"
);  // -> "The quick brown fox jumps over the lazy dog! 1234567890."
```