### PR TITLE
タブ (ウィンドウ) 操作系のメソッドを追加

### DIFF
--- a/src/RPA/WebBrowser.ts
+++ b/src/RPA/WebBrowser.ts
@@ -7,7 +7,8 @@ import {
   ThenableWebDriver,
   WebElement,
   until,
-  Key
+  Key,
+  Alert
 } from "selenium-webdriver";
 import { Command } from "selenium-webdriver/lib/command";
 
@@ -288,6 +289,14 @@ export namespace RPA {
       } else {
         await this.driver.close();
       }
+    }
+
+    /**
+     * Change focus to the active modal dialog,
+     * such as those opened by `window.alert()`, `window.confirm()`, and `window.prompt()`.
+     */
+    public async focusToAlert(): Promise<Alert> {
+      return this.driver.switchTo().alert();
     }
 
     /**

--- a/src/RPA/WebBrowser.ts
+++ b/src/RPA/WebBrowser.ts
@@ -251,6 +251,46 @@ export namespace RPA {
     }
 
     /**
+     * Retrieve the current window handle.
+     */
+    public async getWindowHandle(): Promise<string> {
+      Logger.debug("WebBrowser.getWindowHandle");
+      return this.driver.getWindowHandle();
+    }
+
+    /**
+     * Retrieve the current list of available window handles.
+     */
+    public async getAllWindowHandles(): Promise<string[]> {
+      Logger.debug("WebBrowser.getAllWindowHandles");
+      return this.driver.getAllWindowHandles();
+    }
+
+    /**
+     * Switch the focus of all future commands to another window.
+     */
+    public async switchToWindow(windowHandle: string): Promise<void> {
+      Logger.debug("WebBrowser.switchToWindow", windowHandle);
+      await this.driver.switchTo().window(windowHandle);
+    }
+
+    /**
+     * Close a window.
+     * If no window is specified, close the current window.
+     */
+    public async closeWindow(windowHandle?: string): Promise<void> {
+      Logger.debug("WebBrowser.closeWindow", windowHandle);
+      const currentWindow = await this.driver.getWindowHandle();
+      if (windowHandle != null && windowHandle !== currentWindow) {
+        await this.driver.switchTo().window(windowHandle);
+        await this.driver.close();
+        await this.driver.switchTo().window(currentWindow);
+      } else {
+        await this.driver.close();
+      }
+    }
+
+    /**
      * Enable file downloads in Chrome running in headless mode
      */
     private enableDownloadInHeadlessChrome(): void {

--- a/src/RPA/WebBrowser.ts
+++ b/src/RPA/WebBrowser.ts
@@ -126,6 +126,7 @@ export namespace RPA {
       Logger.debug("WebBrowser.sendKeys");
       return (await element).sendKeys(args);
     }
+
     /* eslint-enable class-methods-use-this */
 
     public findElement(selector: string): Promise<WebElement> {
@@ -211,6 +212,42 @@ export namespace RPA {
     public getCookies(): Promise<IWebDriverOptionsCookie[]> {
       Logger.debug("WebBrowser.getCookies");
       return this.driver.manage().getCookies();
+    }
+
+    /**
+     * Scroll to the element
+     */
+    public async scrollTo(
+      params: { selector?: string } | { xpath?: string }
+    ): Promise<void> {
+      Logger.debug("WebBrowser.scrollTo", params);
+      const escape = (s: string): string =>
+        s
+          .split("")
+          .map((c): string => `\\u{${c.codePointAt(0).toString(16)}}`)
+          .join("");
+
+      let js: string;
+      if ("selector" in params) {
+        js = `{
+          const target = document.querySelector(\`${escape(params.selector)}\`);
+          const x = target.getBoundingClientRect().left + window.pageXOffset - window.innerWidth / 2;
+          const y = target.getBoundingClientRect().top + window.pageYOffset - window.innerHeight / 2;
+          window.scrollTo(x, y);
+        }`;
+      }
+      if ("xpath" in params) {
+        js = `{
+          const result = document.evaluate(\`${escape(
+            params.xpath
+          )}\`, document, null, XPathResult.ANY_TYPE, null);
+          const target = result.iterateNext();
+          const x = target.getBoundingClientRect().left + window.pageXOffset - window.innerWidth / 2;
+          const y = target.getBoundingClientRect().top + window.pageYOffset - window.innerHeight / 2;
+          window.scrollTo(x, y);
+        }`;
+      }
+      return this.driver.executeScript(js);
     }
 
     /**


### PR DESCRIPTION
#84 からブランチを切っています。
タブを操作するメソッドをいくつか追加しました。

```typescript
// タブを切り替える
let currentTab = await RPA.WebBrowser.getWindowHandle();
const anotherTab = (await RPA.WebBrowser.getAllWindowHandles())
  .filter(t => t !== currentTab)[0];
await RPA.WebBrowser.switchToWindow(anotherTab);

// 今のタブ以外をすべて閉じる
currentTab = await RPA.WebBrowser.getWindowHandle();
for (const tab of await RPA.WebBrowser.getAllWindowHandles()) {
  if (tab !== currentTab) {
    await RPA.WebBrowser.closeWindow(tab);
  }
}

// アラートを閉じる
await (await RPA.WebBrowser.focusToAlert()).accept();

```
