### PR TITLE
Add some methods to Google.Spreadsheet

### DIFF
--- a/src/RPA/Google/Spreadsheet.ts
+++ b/src/RPA/Google/Spreadsheet.ts
@@ -319,6 +319,54 @@ export namespace RPA {
             .reduce((ret, ranges) => ret.concat(ranges), [])
         );
       }
+
+      /**
+       * Deletes specified dimension
+       */
+      public async deleteDimension(params: {
+        spreadsheetId: string;
+        range: sheetsApi.Schema$GridRange;
+      }): Promise<void> {
+        Logger.debug("Google.Spreadsheet.deleteDimension", params);
+
+        // converts Schema$GridRange to Schema$DimensionRange
+        const dimensionRanges: sheetsApi.Schema$DimensionRange[] = [];
+        if (
+          params.range.startColumnIndex != null ||
+          params.range.endColumnIndex != null
+        ) {
+          dimensionRanges.push({
+            startIndex: params.range.startColumnIndex,
+            endIndex: params.range.endColumnIndex,
+            sheetId: params.range.sheetId,
+            dimension: "COLUMNS"
+          });
+        }
+        if (
+          params.range.startRowIndex != null ||
+          params.range.endRowIndex != null
+        ) {
+          dimensionRanges.push({
+            startIndex: params.range.startRowIndex,
+            endIndex: params.range.endRowIndex,
+            sheetId: params.range.sheetId,
+            dimension: "ROWS"
+          });
+        }
+
+        await Promise.all(
+          dimensionRanges.map(
+            async (range): Promise<void> => {
+              await this.api.spreadsheets.batchUpdate({
+                spreadsheetId: params.spreadsheetId,
+                requestBody: {
+                  requests: [{ deleteDimension: { range } }]
+                }
+              });
+            }
+          )
+        );
+      }
     }
   }
 }

--- a/src/RPA/Google/Spreadsheet.ts
+++ b/src/RPA/Google/Spreadsheet.ts
@@ -367,6 +367,38 @@ export namespace RPA {
           )
         );
       }
+
+      /**
+       * Sorts the specified range using the column of `keyColumnIndex`.
+       * The default order is ascending.
+       */
+      public async sortRange(params: {
+        spreadsheetId: string;
+        range: sheetsApi.Schema$GridRange;
+        keyColumnIndex: number;
+        desc?: boolean;
+      }): Promise<void> {
+        Logger.debug("Google.Spreadsheet.sortRange", params);
+        const order = params.desc ? "DESCENDING" : "ASCENDING";
+        await this.api.spreadsheets.batchUpdate({
+          spreadsheetId: params.spreadsheetId,
+          requestBody: {
+            requests: [
+              {
+                sortRange: {
+                  range: params.range,
+                  sortSpecs: [
+                    {
+                      dimensionIndex: params.keyColumnIndex,
+                      sortOrder: order
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        });
+      }
     }
   }
 }

--- a/src/RPA/Google/Spreadsheet.ts
+++ b/src/RPA/Google/Spreadsheet.ts
@@ -298,6 +298,27 @@ export namespace RPA {
         });
         Logger.debug("Google.Spreadsheet.deleteProtectedRange", params);
       }
+
+      /**
+       * Lists the protected ranges of a spreadsheet.
+       */
+      public async listProtectedRanges(params: {
+        spreadsheetId: string;
+        sheetId?: number;
+      }): Promise<sheetsApi.Schema$ProtectedRange[]> {
+        Logger.debug("Google.Spreadsheet.listProtectedRanges", params);
+        const data = await this.get({ spreadsheetId: params.spreadsheetId });
+        const sheets = data.sheets.filter(
+          (v): boolean =>
+            params.sheetId == null || v.properties.sheetId === params.sheetId
+        );
+        return (
+          sheets
+            .map(sheet => sheet.protectedRanges || [])
+            // flatten
+            .reduce((ret, ranges) => ret.concat(ranges), [])
+        );
+      }
     }
   }
 }

--- a/src/RPA/Google/Spreadsheet.ts
+++ b/src/RPA/Google/Spreadsheet.ts
@@ -399,6 +399,49 @@ export namespace RPA {
           }
         });
       }
+
+      /**
+       * Finds and replaces data in cells over a range or all sheets.
+       * You must specify either `range` or `allSheets`.
+       */
+      public async findReplace(params: {
+        spreadsheetId: string;
+        range?: sheetsApi.Schema$GridRange;
+        allSheets?: boolean;
+        /** The value to search. */
+        find: string;
+        /** The value to use as the replacement. */
+        replacement: string;
+        /** Set true if the search is case sensitive. */
+        matchCase?: boolean;
+        /** Set true if the find value should match the entire cell. */
+        matchEntireCell?: boolean;
+        /** Set true if the find value is a regex. */
+        searchByRegex?: boolean;
+        /** Set true if the search should include cells with formulas. Set false to skip cells with formulas. */
+        includeFormulas?: boolean;
+      }): Promise<void> {
+        Logger.debug("Google.Spreadsheet.findReplace", params);
+        await this.api.spreadsheets.batchUpdate({
+          spreadsheetId: params.spreadsheetId,
+          requestBody: {
+            requests: [
+              {
+                findReplace: {
+                  range: params.range,
+                  allSheets: params.allSheets,
+                  find: params.find,
+                  replacement: params.replacement,
+                  matchCase: params.matchCase,
+                  matchEntireCell: params.matchEntireCell,
+                  searchByRegex: params.searchByRegex,
+                  includeFormulas: params.includeFormulas
+                }
+              }
+            ]
+          }
+        });
+      }
     }
   }
 }


### PR DESCRIPTION
https://github.com/ca-rpa/ts-rpa/pull/82 からブランチを切っています

```typescript
const spreadsheetId = "...";

// 指定したシートの B, C 列および 3, 4, 5 行目を削除する
await RPA.Google.Spreadsheet.deleteDimension({
  spreadsheetId,
  range: {
    sheetId: ...,
    startColumnIndex: 1,
    endColumnIndex: 3,
    startRowIndex: 2,
    endRowIndex: 5,
  }
});

// 指定したシートのB,C,D列の3行目以下をB列の降順でソートする
await RPA.Google.Spreadsheet.sortRange({
  spreadsheetId,
  range: {
    sheetId: ...,
    startColumnIndex: 1,
    endColumnIndex: 4,
    startRowIndex: 2
  },
  keyColumnIndex: 1,
  desc: true
});

// 指定したシートの E 列までを置換する
await RPA.Google.Spreadsheet.findReplace({
  spreadsheetId,
  range: {
    sheetId: ...,
    endColumnIndex: 5,
  },
  find: 'RPA',
  replacement: 'Robotic Process Automation',
});
```