### PR TITLE
Don't remove comments from declaration files

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "baseUrl": "src/",
     "sourceMap": true,
     "declaration": true,
-    "removeComments": true,
+    "removeComments": false
   },
   "include": [
       "src/**/*"


### PR DESCRIPTION
IDE から TypeDoc のコメントを読めるようビルド時に消さないようにしました。