### PR TITLE
retry に渡した関数の例外を catch できるようにする

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -67,27 +67,17 @@ export namespace RPA {
     });
   };
 
+  /**
+   * Executes up to `retryCount` times until `asyncFunc` resolves
+   */
   export const retry = <T>(
     asyncFunc: () => Promise<T>,
     retryCount = 3
   ): Promise<T> => {
-    const uniqueObj = {};
     const nums = Array.from(Array(retryCount));
-    return nums.reduce(
-      (prm, _, i): any =>
-        prm.catch(
-          (err): Promise<T> =>
-            err !== uniqueObj
-              ? Promise.reject(err)
-              : asyncFunc().catch(
-                  (): Promise<never> =>
-                    sleep(i * 1000).then(
-                      (): Promise<never> => Promise.reject(uniqueObj)
-                    )
-                )
-        ),
-      Promise.reject(uniqueObj)
-    );
+    return nums.reduce((prm, _, i): Promise<T> => {
+      return prm.catch((): Promise<T> => sleep(i * 1000).then(asyncFunc));
+    }, Promise.reject());
   };
 }
 

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -1,0 +1,41 @@
+import { RPA } from "../src/index";
+
+describe("RPA", (): void => {
+  describe("retry", (): void => {
+    it("executes functions that are always resolved only once", async (): Promise<
+      void
+    > => {
+      let count = 0;
+      await RPA.retry(
+        async (): Promise<void> => {
+          count += 1;
+        }
+      );
+      expect(count).toBe(1);
+    });
+
+    it("executes functions until resolved", async (): Promise<void> => {
+      let count = 0;
+      await RPA.retry(async (): Promise<void> => {
+        count += 1;
+        if (count <= 1) throw new Error();
+      }, 3);
+      expect(count).toBe(2);
+    });
+
+    it("executes functions that are always rejected `retryCount` times", async (): Promise<
+      void
+    > => {
+      let count = 0;
+      try {
+        await RPA.retry(async (): Promise<void> => {
+          count += 1;
+          throw new Error("test error message");
+        }, 3);
+      } catch (e) {
+        expect(e.message).toBe("test error message");
+      }
+      expect(count).toBe(3);
+    });
+  });
+});


### PR DESCRIPTION
`retry` の中で起きた例外を `catch` できるようにしました。
https://github.com/ca-rpa/ts-rpa/pull/91/files#diff-f41e9d04a45c83f3b6f6e630f10117feL85
常に `reject` に `uniqueObj` を渡していたのを、代わりに `asyncFunction` の結果の `Promise` をそのまま返すようにしました。

```typescript
try {
  await retry(async () => {
    throw new Error("asyncFunction error");
  });
} catch (e) {
  console.log(e.toString()); // -> Error: asyncFunction error
}
```