### PR TITLE
Use goog:chromeOptions for Chrome Options

### DIFF
--- a/src/RPA/WebBrowser.ts
+++ b/src/RPA/WebBrowser.ts
@@ -72,7 +72,11 @@ export namespace RPA {
             "Mozilla/5.0 (Linux; Android 4.2.1; en-us; Nexus 5 Build/JOP40D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19"
         };
       }
-      this.capabilities.set("chromeOptions", { args, prefs, mobileEmulation });
+      this.capabilities.set("goog:chromeOptions", {
+        args,
+        prefs,
+        mobileEmulation
+      });
       this.driver = new Builder().withCapabilities(this.capabilities).build();
       this.enableDownloadInHeadlessChrome();
     }


### PR DESCRIPTION
Chrome 76 になって headless などのオプションが効かなくなっていたのを修正しました。

https://github.com/SeleniumHQ/selenium/issues/7476#issuecomment-519938952
https://github.com/zbigg/mocha-webdriver-runner/commit/9c8970015255fa2d2d753817ee0aef581e9010a9

