### PR TITLE
File.list の引数を省略できるようにする

### DIFF
--- a/src/RPA/File.ts
+++ b/src/RPA/File.ts
@@ -112,7 +112,7 @@ export namespace RPA {
       const dirname = (params && params.dirname) || "./";
       Logger.debug("File.list", { dirname });
       const fileList = fs.readdirSync(path.join(this.outDir, dirname));
-      if (params.sortType) {
+      if (params && params.sortType) {
         Logger.debug("File.list->sort", { params });
         if (params.sortType === SortType.Name) {
           fileList.sort(

--- a/src/RPA/File.ts
+++ b/src/RPA/File.ts
@@ -105,7 +105,7 @@ export namespace RPA {
     }
 
     public static list(params?: {
-      dirname: string;
+      dirname?: string;
       sortType?: SortType;
       orderBy?: OrderBy;
     }) {
@@ -142,7 +142,7 @@ export namespace RPA {
     }
 
     public static listFiles(params?: {
-      dirname: string;
+      dirname?: string;
       sortType?: SortType;
       orderBy?: OrderBy;
     }): string[] {


### PR DESCRIPTION
`listFiles` のパラメータ指定を省略できるようにしました。

```typescript
const files1 = RPA.File.listFiles();
const files2 = RPA.File.listFiles({ sortType: RPA.File.SortType.Mtime });
```