### PR TITLE
Add Spreadsheet.ctoi

### DIFF
--- a/src/RPA/Google/Spreadsheet.ts
+++ b/src/RPA/Google/Spreadsheet.ts
@@ -442,6 +442,29 @@ export namespace RPA {
           }
         });
       }
+
+      /**
+       * Converts a column name to a number (0-indexed).
+       * A -> 0
+       * Z -> 25
+       * AA -> 26
+       * AZ -> 51
+       * BA -> 52
+       */
+      // eslint-disable-next-line class-methods-use-this
+      public ctoi(column: string): number {
+        if (!column.match(/^[A-Za-z]+$/g)) {
+          throw new Error("Invalid column name");
+        }
+        return column
+          .toUpperCase()
+          .split("")
+          .reduce(
+            (ret, c): number =>
+              (ret + 1) * 26 + c.codePointAt(0) - "A".codePointAt(0),
+            -1
+          );
+      }
     }
   }
 }


### PR DESCRIPTION
列の名前を、左から何列目かの数値に変換できるようにしました。

```typescript
let i;
i = RPA.Google.Spreadsheet.ctoi("A");  // 0
i = RPA.Google.Spreadsheet.ctoi("Z");  // 25
i = RPA.Google.Spreadsheet.ctoi("AA"); // 26
i = RPA.Google.Spreadsheet.ctoi("AZ"); // 51
i = RPA.Google.Spreadsheet.ctoi("BA"); // 52
```