### PR TITLE
Chatwork.postMessage で message id を返すようにする

### DIFF
--- a/src/RPA/Chatwork.ts
+++ b/src/RPA/Chatwork.ts
@@ -31,19 +31,25 @@ export namespace RPA {
 
     /**
      * Post a message to the chat.
+     * @returns A message id
      */
     public async postMessage(params: {
       roomId: string;
       message: string;
-    }): Promise<void> {
+    }): Promise<string> {
       Logger.debug("Chatwork.postMessage", params);
-      await this.request({
+      const res = await this.request({
         url: `https://api.chatwork.com/v2/rooms/${params.roomId}/messages`,
         method: "POST",
         data: {
           body: params.message
         }
       });
+      const data = await res.json();
+      if (res.ok && "message_id" in data) {
+        return data.message_id;
+      }
+      throw new Error(JSON.stringify(data));
     }
 
     /**


### PR DESCRIPTION
チャットの投稿失敗を検知する手段がなかったため、正常時にはメッセージ ID を返し、失敗時には例外を投げるようにしました。